### PR TITLE
uplink-sys: Allow typedef ERROR constants in Bindgen

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
 edition = "2018"
 link = "uplink"

--- a/uplink-sys/build.rs
+++ b/uplink-sys/build.rs
@@ -66,6 +66,7 @@ fn main() {
         .allowlist_type("uplink_const_char")
         // All uplink functions start with uplink_
         .allowlist_function("uplink_.*")
+        .allowlist_var("UPLINK_ERROR_.*")
         // This header file is the main API interface and includes all other header files that are required
         // (bindgen runs c preprocessor so we don't need to include nested headers)
         .header(

--- a/uplink-sys/build.rs
+++ b/uplink-sys/build.rs
@@ -66,6 +66,7 @@ fn main() {
         .allowlist_type("uplink_const_char")
         // All uplink functions start with uplink_
         .allowlist_function("uplink_.*")
+        // Uplink error code #define's start with UPLINK_ERROR_
         .allowlist_var("UPLINK_ERROR_.*")
         // This header file is the main API interface and includes all other header files that are required
         // (bindgen runs c preprocessor so we don't need to include nested headers)


### PR DESCRIPTION
White list he typedef constants prefixed with UPLINK_ERROR_ in the
uplink-c in Bindgen so they are processed to be available in Rust.