### PR TITLE
uplink-sys(build): Fix key in cargo & bump edition

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -2,15 +2,13 @@
 name = "uplink-sys"
 version = "0.1.1"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
-edition = "2018"
-link = "uplink"
+edition = "2021"
+links = "uplink"
 description = "Unsafe rust bindings for libuplink - the storj protocol library."
 readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/storj-thirdparty/uplink-rust"
 keywords = ["storj", "storage"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
 bindgen = "0.58.1"


### PR DESCRIPTION
Fix the `links` Cargo key, bump the Rust edition and remove a comment
which is added when a Cargo project is initialized.

I've diffted the build output and there isn't any result difference.