### PR TITLE
uplink-sys(build): Bump bindgen version

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/storj-thirdparty/uplink-rust"
 keywords = ["storj", "storage"]
 
 [build-dependencies]
-bindgen = "0.58.1"
+bindgen = "0.59.1"
 
 [dependencies]

--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -2,15 +2,13 @@
 name = "uplink-sys"
 version = "0.1.1"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
-edition = "2018"
-link = "uplink"
+edition = "2021"
+links = "uplink"
 description = "Unsafe rust bindings for libuplink - the storj protocol library."
 readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/storj-thirdparty/uplink-rust"
 keywords = ["storj", "storage"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
 bindgen = "0.58.1"


### PR DESCRIPTION
Bump the Bindgen version to the last published release.

__NOTE__ it's on top of #5  so review and merge that one before this one.