### PR TITLE
uplink-sys(deps): Bump uplink-c version to v1.5.0

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink-sys"
-version = "0.1.1"
+version = "0.2.1"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
 edition = "2021"
 links = "uplink"
@@ -9,6 +9,10 @@ readme = "README.md"
 license = "Apache-2.0"
 repository = "https://github.com/storj-thirdparty/uplink-rust"
 keywords = ["storj", "storage"]
+
+# Contains relevant information of the Uplink c-binding.
+[package.metadata.uplink-c]
+version = "1.5.0" # keep it manually in sync with the git-submodule uplink-c checkout version tag.
 
 [build-dependencies]
 bindgen = "0.59.1"

--- a/uplink/README.md
+++ b/uplink/README.md
@@ -13,26 +13,44 @@ offering an safe and idiomatic Rust [Storj Uplink][storj-uplink].
 
 ### Development plan and status
 
-Entities:
+General entities:
 
 - [ ] [Access](https://pkg.go.dev/storj.io/uplink#Access)
 - [ ] [Bucket](https://pkg.go.dev/storj.io/uplink#Bucket)
 - [ ] [Bucket Iterator](https://pkg.go.dev/storj.io/uplink#BucketIterator)
 - [ ] [Config](https://pkg.go.dev/storj.io/uplink#Config)
+- [ ] [Commit Upload Options](https://pkg.go.dev/storj.io/uplink#CommitUploadOptions)
 - [ ] [Custom Metadata](https://pkg.go.dev/storj.io/uplink#CustomMetadata)
 - [ ] [Download](https://pkg.go.dev/storj.io/uplink#Download)
 - [ ] [Download Options](https://pkg.go.dev/storj.io/uplink#DownloadOptions)
 - [ ] [Encryption Key](https://pkg.go.dev/storj.io/uplink#EncryptionKey)
 - [ ] [List Buckets Options](https://pkg.go.dev/storj.io/uplink#ListBucketsOptions)
 - [ ] [List Objects Options](https://pkg.go.dev/storj.io/uplink#ListObjectsOptions)
+- [ ] [List Upload Options](https://pkg.go.dev/storj.io/uplink#ListUploadsOptions)
+- [ ] [List Upload Parts Options](https://pkg.go.dev/storj.io/uplink#ListUploadPartsOptions)
+- [ ] [Move Object Options](https://pkg.go.dev/storj.io/uplink#MoveObjectOptions)
 - [ ] [Object](https://pkg.go.dev/storj.io/uplink#Object)
 - [ ] [Object Iterator](https://pkg.go.dev/storj.io/uplink#ObjectIterator)
+- [ ] [Part](https://pkg.go.dev/storj.io/uplink#Part)
+- [ ] [Part Iterator](https://pkg.go.dev/storj.io/uplink#PartIterator)
+- [ ] [Part Upload](https://pkg.go.dev/storj.io/uplink#PartUpload)
 - [ ] [Permission](https://pkg.go.dev/storj.io/uplink#Permission)
 - [ ] [Project](https://pkg.go.dev/storj.io/uplink#Project)
 - [ ] [Share Prefix](https://pkg.go.dev/storj.io/uplink#SharePrefix)
 - [ ] [System Metadata](https://pkg.go.dev/storj.io/uplink#SystemMetadata)
 - [ ] [Upload](https://pkg.go.dev/storj.io/uplink#Upload)
+- [ ] [Upload Info](https://pkg.go.dev/storj.io/uplink#UploadInfo)
+- [ ] [Upload Iterator](https://pkg.go.dev/storj.io/uplink#UploadIterator)
 - [ ] [Upload Options](https://pkg.go.dev/storj.io/uplink#UploadOptions)
+
+
+Edge entities:
+
+- [ ] [Config](https://pkg.go.dev/storj.io/uplink/edge#Config)
+- [ ] [Credentials](https://pkg.go.dev/storj.io/uplink/edge#Credentials)
+- [ ] [Register Access Options](https://pkg.go.dev/storj.io/uplink/edge#RegisterAccessOptions)
+- [ ] [Share URL Options](https://pkg.go.dev/storj.io/uplink/edge#ShareURLOptions)
+
 
 Integration tests:
 
@@ -50,12 +68,17 @@ Integration tests:
   - [ ] List Buckets.
   - [ ] Upload an Object.
   - [ ] Upload an Object with Custom Metadata.
+  - [ ] Multipart upload.
   - [ ] Download an Object.
   - [ ] Stat an Object.
   - [ ] List Objects with and without System and Custom Metadata.
+  - [ ] Move an object.
   - [ ] Delete an Object.
   - [ ] Delete an empty Bucket.
   - [ ] Delete a Bucket with objects.
+- [ ] Edge.
+  - [ ] Join a share URL.
+  - [ ] Register an Access Grant.
 
 General:
 


### PR DESCRIPTION
Bump the version of the Uplink C bindings to the last published release
which is v1.5.0.

Add some metadata to Cargo regarding Uplink C bindings and bump the
crate version.

Add the new entities to implement in `uplink` crate because of the new
additions that the new Uplink-C has and also some new integration test
to implement regarding to them.