### PR TITLE
uplink-sys(cargo): Fix version before publishing it

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink-sys"
-version = "0.2.1"
+version = "0.2.0"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
 edition = "2021"
 links = "uplink"


### PR DESCRIPTION
In a previous commit the version for Uplink-c was bumped and the version
of the `uplink-sys` crate too, however, the `uplink-sys` version wasn't
properly increased although it wouldn't break anything.

This commit set the proper version taking advantage that so far the new
version has not been published yet in crates.io.