### PR TITLE
uplink-sys(deps): Bump uplink-c version to v1.6.1

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink-sys"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
 edition = "2021"
 links = "uplink"
@@ -12,9 +12,9 @@ keywords = ["storj", "storage"]
 
 # Contains relevant information of the Uplink c-binding.
 [package.metadata.uplink-c]
-version = "1.5.0" # keep it manually in sync with the git-submodule uplink-c checkout version tag.
+version = "1.6.1" # keep it manually in sync with the git-submodule uplink-c checkout version tag.
 
 [build-dependencies]
-bindgen = "0.59.1"
+bindgen = "0.59.2"
 
 [dependencies]

--- a/uplink-sys/Makefile
+++ b/uplink-sys/Makefile
@@ -12,7 +12,7 @@ test: $(UPLINK_C)/.git
 	cargo test
 
 .PHONY: publish-test
-publish-test: $(UPLINK_C)/.git
+publish-test: clean $(UPLINK_C)/.git
 	cargo publish --dry-run -vv
 
 .PHONY: _publish-crate
@@ -25,4 +25,5 @@ $(UPLINK_C)/.git:
 
 .PHONY: clean
 clean:
+	@rm -rf uplink-c/.build
 	cargo clean

--- a/uplink-sys/tests/list_buckets.rs
+++ b/uplink-sys/tests/list_buckets.rs
@@ -6,10 +6,16 @@ fn list_buckets() {
     // Get secrets for accessing project
     let secrets = fs::read_to_string("test_secrets.txt").unwrap();
     let secrets = secrets.lines().collect::<Vec<&str>>();
+    assert_eq!(
+        secrets.len(),
+        3,
+        "test_secrets.txt file has to contain 3 lines, satellite address, API key, and passphrase"
+    );
+
     // Access parameters
     let satellite_address = CString::new(secrets[0]).expect("CString::new failed");
     let api_key = CString::new(secrets[1]).expect("CString::new failed");
-    let passphrase = CString::new("").expect("CString::new failed");
+    let passphrase = CString::new(secrets[2]).expect("CString::new failed");
 
     unsafe {
         // Request access


### PR DESCRIPTION
Bump the uplink-c version to 1.6.1 (the last published version so far).

Arrange the build script for making it work with Go 1.18 but keeping
compatibility with the previous supported Go versions.

Enhance the test to read the passphrase from the secrets file rather
than requiring to be empty because the satellite web UI doesn't
currently allow setting an empty passphrase.

Closes #9

Once it's approved and merged, I will create the tag and publish the new crate version on crates.io