### PR TITLE
uplink-sys(build): Allow edge entities to bingen

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink-sys"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
 edition = "2021"
 links = "uplink"

--- a/uplink-sys/build.rs
+++ b/uplink-sys/build.rs
@@ -72,15 +72,21 @@ fn main() {
     bindgen::Builder::default()
         // Use 'allow lists' to avoid generating bindings for system header includes
         // a lot of which isn't required and can't be handled safely anyway.
-        // uplink-c uses consistent naming so whitelisting is much easier than blacklisting.
+        // uplink-c uses consistent naming so an allow list is much easier than a block list.
         // All uplink types start with Uplink
         .allowlist_type("Uplink.*")
+        // All edge services types start with Edge
+        .allowlist_type("Edge.*")
         // except for uplink_const_char
         .allowlist_type("uplink_const_char")
         // All uplink functions start with uplink_
         .allowlist_function("uplink_.*")
+        // All edge services functions start with edge_
+        .allowlist_function("edge_.*")
         // Uplink error code #define's start with UPLINK_ERROR_
         .allowlist_var("UPLINK_ERROR_.*")
+        // Edge services error code #define's start with EDGE_ERROR_
+        .allowlist_var("EDGE_ERROR_.*")
         // This header file is the main API interface and includes all other header files that are required
         // (bindgen runs c preprocessor so we don't need to include nested headers)
         .header(


### PR DESCRIPTION
The Uplink-c bindings also have some Storj DCS Edge services
functionalities.

Add all the Edge services entities to the bingen allow list so it can
generate the corresponding Rust bindings.

__NOTE__ once it's merged we have to update the uplink-sys crate
