### PR TITLE
uplink-sys(deps): Bump uplink-c version to v1.7.0

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink-sys"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
 edition = "2021"
 links = "uplink"
@@ -12,7 +12,7 @@ keywords = ["storj", "storage"]
 
 # Contains relevant information of the Uplink c-binding.
 [package.metadata.uplink-c]
-version = "1.6.1" # keep it manually in sync with the git-submodule uplink-c checkout version tag.
+version = "1.7.0" # keep it manually in sync with the git-submodule uplink-c checkout version tag.
 
 [build-dependencies]
 bindgen = "0.59.2"


### PR DESCRIPTION
Bump the uplink-c version to 1.7.0 (the last published so far).

We have bumped to this new minor version without updating to the next
patch version because the next patch version only had changes in the
dependencies, nothing from the API was changed, removed, or added.

Related to #15