### PR TITLE
uplink(fix): Make a ctor & member public

### DIFF
--- a/uplink/src/access.rs
+++ b/uplink/src/access.rs
@@ -70,7 +70,7 @@ impl Grant {
     /// NOTE: this is a CPU-heavy operation that uses a password-based key derivation (Argon2). It
     /// should be a setup-only step. Most common interactions with the library should be using a
     /// serialized access grant through [`Grant::new()`](../access/struct.Grant.html#.method.new).
-    fn request_access_with_config_and_passphrase(
+    pub fn request_access_with_config_and_passphrase(
         config: &Config,
         satellite_addr: &str,
         api_key: &str,

--- a/uplink/src/encryption_key.rs
+++ b/uplink/src/encryption_key.rs
@@ -40,7 +40,7 @@ impl EncryptionKey {
             )
         };
 
-        (&uc_res).ensure();
+        uc_res.ensure();
 
         if let Some(err) = Error::new_uplink(uc_res.error) {
             // SAFETY: we trust the FFI is safe freeing the memory of a valid pointer.

--- a/uplink/src/object/upload.rs
+++ b/uplink/src/object/upload.rs
@@ -217,7 +217,7 @@ pub struct Info<'a> {
     /// The system metadata associated to the upload.
     pub metadata_system: metadata::System,
     /// The custom metadata associated to the upload.
-    metadata_custom: metadata::Custom,
+    pub metadata_custom: metadata::Custom,
 }
 
 impl Info<'_> {


### PR DESCRIPTION
Rust linter shows some warning about functions, methods, and members
visibility.

Not always those warnings apply because it doesn't consider that some
members are read if they are passed to the FFI as raw pointers, however,
it was right for these ones. These ones must be public otherwise the
dependents of this crate cannot use them.

The commit also remove an explicit borrow because the compiler is
already doing it automatically. This was reported as an error by a newer
version of Clippy running on local.