### PR TITLE
all(release): Bump version to all crates

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink-sys"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
 edition = "2021"
 links = "uplink"

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Ivan Fraixedes <ivan@fraixed.es>"]
 edition = "2021"
 description = "Idiomatic and safe Rust binding for the Storj Lib Uplink"
@@ -12,4 +12,4 @@ homepage = "https://storj.io"
 
 
 [dependencies]
-uplink-sys = { path = "../uplink-sys", version = "0.5.1" }
+uplink-sys = { path = "../uplink-sys", version = "0.5.2" }


### PR DESCRIPTION
Bump the version to all the crates in this repository.

This new `uplink-sys` version includes a workaround for making possible
to build the documentation of the `uplink-sys` by docs.rs, and
consequently, for any crate that depends on it.

The new `uplink` version exposes with public visibility some existing
functions and fields that weren't exposed initially by mistake and
address a Clippy error. It also updates the `uplink-sys` dependency to
the version that this commit bumps.

---

Once it's merged, I'll create the new tags and publish the version of each crate.

- [ ] I (the merger of this PR) confirm that I'm copying the PR message above the line as the message of the commit that merge these changes to the main branch.