### PR TITLE
all(doc): Add missing badges to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # uplink-rust
 
+[![CI Status](https://img.shields.io/github/workflow/status/storj-thirdparty/uplink-rust/uplink?style=for-the-badge)](https://github.com/storj-thirdparty/uplink-rust/actions/workflows/uplink.yml)
+[![crates.io](https://img.shields.io/crates/v/uplink.svg?style=for-the-badge)](https://crates.io/crates/uplink)
+[![docs.rs](https://img.shields.io/docsrs/uplink?style=for-the-badge)](https://docs.rs/uplink)
+![Crates.io](https://img.shields.io/crates/d/uplink?style=for-the-badge)
+
 Storj Uplink Rust bindings for the Rust programming language.
 
 ## Repository layout

--- a/uplink-sys/README.md
+++ b/uplink-sys/README.md
@@ -1,7 +1,9 @@
 # uplink-sys
 
-[![Actions Status](https://github.com/storj-thirdparty/uplink-rust/workflows/uplink-sys/badge.svg)](https://github.com/storj-thirdparty/uplink-rust/actions)
-[![Crates.io](https://img.shields.io/crates/v/uplink-sys)](https://crates.io/crates/uplink-sys)
+[![CI Status](https://img.shields.io/github/workflow/status/storj-thirdparty/uplink-rust/uplink-sys?style=for-the-badge)](https://github.com/storj-thirdparty/uplink-rust/actions/workflows/uplink-sys.yml)
+[![Crates.io](https://img.shields.io/crates/v/uplink-sys?style=for-the-badge)](https://crates.io/crates/uplink-sys)
+[![docs.rs](https://img.shields.io/docsrs/uplink-sys?style=for-the-badge)](https://docs.rs/uplink-sys)
+![Crates.io](https://img.shields.io/crates/d/uplink-sys?style=for-the-badge)
 
 This crate provides auto-generated unsafe Rust bindings, through [bindgen](https://github.com/rust-lang/rust-bindgen/), to C functions provided by [uplink-c](https://github.com/storj/uplink-c/), the C interface for the Storj uplink API library.
 

--- a/uplink/README.md
+++ b/uplink/README.md
@@ -1,5 +1,10 @@
 # Storj Uplink Library for Rust
 
+[![CI Status](https://img.shields.io/github/workflow/status/storj-thirdparty/uplink-rust/uplink?style=for-the-badge)](https://github.com/storj-thirdparty/uplink-rust/actions/workflows/uplink.yml)
+[![crates.io](https://img.shields.io/crates/v/uplink.svg?style=for-the-badge)](https://crates.io/crates/uplink)
+[![docs.rs](https://img.shields.io/docsrs/uplink?style=for-the-badge)](https://docs.rs/uplink)
+![Crates.io](https://img.shields.io/crates/d/uplink?style=for-the-badge)
+
 Safe and idiomatic Rust crate library for the [Storj Uplink Library][storj-uplink].
 
 ## Current status
@@ -90,7 +95,7 @@ Integration tests:
 
 General:
 
-- [ ] Add a CI solution (Travis, Github actions, etc.) for running tests,
+- [X] Add a CI solution (Travis, Github actions, etc.) for running tests,
       linters on every PR and when something is merge into the `main` branch.
 - [ ] Add general documentation about the Storj network and its entities
       mimicking the original [Go Uplink package](https://pkg.go.dev/storj.io/uplink#section-documentation).


### PR DESCRIPTION
Add badges to all the READMES.
The badges are:

* Github actions status.
* Crates.io latest published version.
* Docs.rs link to the docs of the latest version.
* Crates.io downloads

The main README reference to the `uplink` crate because it's the
idiomatic and safe implementation, hence everybody should use that one.

The README of each specific crate links to its own Github action,
Crates.io, and Docs.io.

Before this only the `uplink-sys` README had Github actions badges and
crates.io.

This commit also changes the style of the badge and mark as done one fo
the tasks listed in the `uplink` README which was missed when it was
completed.

Closes #25