### PR TITLE
uplink(fix): Retry on length 0 when downloading

### DIFF
--- a/uplink/tests/full_cycle_test.rs
+++ b/uplink/tests/full_cycle_test.rs
@@ -81,15 +81,11 @@ fn integration_create_upload_list_download_delete() {
         "downloaded object created at",
     );
 
-    let downloaded_object_data = &mut vec![0; object_data.len()];
+    let mut downloaded_object_data = String::new();
     download
-        .read(downloaded_object_data)
+        .read_to_string(&mut downloaded_object_data)
         .expect("download object read");
-    assert_eq!(
-        object_data,
-        String::from_utf8_lossy(downloaded_object_data),
-        "object data"
-    );
+    assert_eq!(object_data, downloaded_object_data, "object data");
 
     let deleted_object = project
         .delete_object(&bucket_name, object_key)


### PR DESCRIPTION
The Uplink-c library may return 0 bytes read when downloading an object,
despite not all the data being read. This usually happens when the object
has more than one segment and the read happens between the segments'
boundaries

Without retrying the crate won't allow downloading the entire object's
data when it has more than one segment.

On the other hand, a reader
(https://doc.rust-lang.org/std/io/trait.Read.html) implementation offers
a great number of useful methods out of the box with only implementing
the `read` method, however, read has only to return 0 bytes read when
there is no more data to read, rather than returning EOF as an error.
This commit identifies when Uplink-c returns the EOF error and returns
no error with the bytes read, that in case of not being 0, Rust will
call it again, and then it will again get the EOF error but with 0 bytes
read.

---

Related to https://github.com/storj/uplink/issues/99