### PR TITLE
uplink(release): Bump version due to several fixes

### DIFF
--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ivan Fraixedes <ivan@fraixed.es>"]
 edition = "2021"
 description = "Idiomatic and safe Rust binding for the Storj Lib Uplink"


### PR DESCRIPTION
Bump the version of the uplink crate after a few commits that have fixed
some bugs and make the crate usable.

We know that those fixes made it usable because we had our first
integration test that it does a basic full-cycle and without them the
test wouldn't have passed.

I forgot to add this commit in the PR #28 I need this for releasing the new version