### PR TITLE
Fix storj-up after latest is broken

### DIFF
--- a/uplink/Makefile
+++ b/uplink/Makefile
@@ -49,9 +49,6 @@ integration-tests-env-up:
 .integration-tests-env-down:
 	cd tests; docker compose down
 
-tests/.tmp/integration-tests-env-vars:
-
-
 tests/.tmp/up/storj-up: tests/.tmp/up
 	cd tests/.tmp/up; go build -o storj-up
 

--- a/uplink/Makefile
+++ b/uplink/Makefile
@@ -55,6 +55,9 @@ tests/.tmp/up/storj-up: tests/.tmp/up
 tests/.tmp/up:
 	mkdir -p tests/.tmp
 	cd tests/.tmp; git clone https://github.com/storj/up.git
+	# Checkout this commit because storj-up was working fine, the latest commit in
+	# main at this time is broken.
+	cd tests/.tmp/up; git checkout 37026d04259495be27d978a6950fae3205322be1
 
 ## Publish crate ##
 .PHONY: publish-test


### PR DESCRIPTION
We relied on storj-up latest commit in the main branch however new
recent commits have broken it.

To not break it in our local and CI environments, we are compiling
storj-up in a commit that worked when we started to use it here at the
expense that we'll have to update from time to time.

On the other hand, we have requested to start using tag versions in the
storj-up repository because of this.

There is also another commit to remove an empty makefile target that was left
when working on #28 