### PR TITLE
Uplink: Add integration test for Edge services API

### DIFF
--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Ivan Fraixedes <ivan@fraixed.es>"]
 edition = "2021"
 description = "Idiomatic and safe Rust binding for the Storj Lib Uplink"

--- a/uplink/README.md
+++ b/uplink/README.md
@@ -86,7 +86,7 @@ Integration tests:
   - [X] Parse one.
   - [X] Share one.
   - [X] Override an encryption key of a specific Bucket and prefix.
-- [ ] Project
+- [X] Project
   - [X] Create a Bucket.
   - [X] Try to create a Bucket which already exists.
   - [X] Ensure a Bucket, an existing and non-existing one.
@@ -104,9 +104,9 @@ Integration tests:
   - [X] Delete an Object.
   - [X] Delete an empty Bucket.
   - [X] Delete a Bucket with objects.
-- [ ] Edge.
-  - [ ] Join a share URL.
-  - [ ] Register an Access Grant.
+- [X] Edge.
+  - [X] Join a share URL.
+  - [ ] Register an Access Grant. - NOTE: [waiting to know if we can test it with storj/up](https://github.com/storj/up/issues/59)
 
 General:
 

--- a/uplink/src/edge/config.rs
+++ b/uplink/src/edge/config.rs
@@ -55,11 +55,6 @@ impl Config {
                 certificate_pem: ptr::null_mut(),
             },
         })
-
-        // Ok(Self {
-        //     auth_service_addr,
-        //     certificate_pem: None,
-        // })
     }
 
     /// Creates a new configuration that uses the specified Auth service address and the root
@@ -100,7 +95,7 @@ impl Config {
     /// access grant if the use case doesn't have a specific constraint for not doing it.
     pub fn register_gateway_access(
         &self,
-        access: access::Grant,
+        access: &access::Grant,
         opts: Option<&OptionsRegisterAccess>,
     ) -> Result<credentials::Gateway> {
         let uc_opts = if let Some(o) = opts {

--- a/uplink/tests/edge_test.rs
+++ b/uplink/tests/edge_test.rs
@@ -1,0 +1,260 @@
+use uplink::access::Grant;
+use uplink::edge;
+
+mod common;
+
+const AUTH_SERVICE_URL: &str = "localhost:8888";
+
+// #[test]
+fn integration_config_register_access() {
+    // TODO: See evolution of https://github.com/storj/up/issues/59 for enabling or removing this
+    // test.
+    let env = common::Environment::load();
+    let access_grant = Grant::new(&env.access_grant).expect("access grant parsing");
+
+    let config = edge::Config::new(AUTH_SERVICE_URL).expect("Edge config from AUTH service URL");
+    let creds = config
+        .register_gateway_access(&access_grant, None)
+        .expect("Gateway credentials");
+    assert_eq!(env.aws_access_key_id, creds.access_key_id, "access key ID");
+    assert_eq!(env.aws_secret_access_key, creds.secret_key, "secret key");
+    assert!(creds.endpoint != "", "not empty endpoint");
+}
+
+#[test]
+fn integration_join_share_url() {
+    const BASE_URL: &str = "https://link.us1.storjshare.io";
+    let env = common::Environment::load();
+
+    {
+        // No bucket, no key.
+        let url = edge::linksharing::share_url(BASE_URL, &env.aws_access_key_id, "", "", None)
+            .expect("shared URL without bucket");
+        assert!(
+            url.starts_with(BASE_URL),
+            "must start with '{}', got '{}'",
+            BASE_URL,
+            url
+        );
+        assert!(
+            url.contains(&env.aws_access_key_id),
+            "must contain '{}', got '{}'",
+            env.aws_access_key_id,
+            url
+        );
+    }
+
+    {
+        // With bucket, no key.
+        let url =
+            edge::linksharing::share_url(BASE_URL, &env.aws_access_key_id, "my-bucket", "", None)
+                .expect("shared URL without bucket");
+        assert!(
+            url.starts_with(BASE_URL),
+            "must start with '{}', got '{}'",
+            BASE_URL,
+            url
+        );
+        assert!(
+            url.contains(&env.aws_access_key_id),
+            "must contain '{}', got '{}'",
+            env.aws_access_key_id,
+            url
+        );
+        assert!(
+            url.contains("my-bucket"),
+            "must contain 'my-bucket', got '{}'",
+            url
+        );
+    }
+
+    {
+        // With bucket, and key
+        let url = edge::linksharing::share_url(
+            BASE_URL,
+            &env.aws_access_key_id,
+            "my-bucket",
+            "obj-name",
+            None,
+        )
+        .expect("shared URL without bucket");
+        assert!(
+            url.starts_with(BASE_URL),
+            "must start with '{}', got '{}'",
+            BASE_URL,
+            url
+        );
+        assert!(
+            url.contains(&env.aws_access_key_id),
+            "must contain '{}', got '{}'",
+            env.aws_access_key_id,
+            url
+        );
+        assert!(
+            url.contains("my-bucket"),
+            "must contain 'my-bucket', got '{}'",
+            url
+        );
+        assert!(
+            url.contains("obj-name"),
+            "must contain 'obj-name', got '{}'",
+            url
+        );
+    }
+
+    {
+        // With bucket, and key
+        let url = edge::linksharing::share_url(
+            BASE_URL,
+            &env.aws_access_key_id,
+            "my-bucket-name",
+            "obj-name-2",
+            Some(&edge::linksharing::OptionsShareURL { raw: true }),
+        )
+        .expect("shared URL without bucket");
+        assert!(
+            url.starts_with(BASE_URL),
+            "must start with '{}', got '{}'",
+            BASE_URL,
+            url
+        );
+        assert!(
+            url.contains(&env.aws_access_key_id),
+            "must contain '{}', got '{}'",
+            env.aws_access_key_id,
+            url
+        );
+        assert!(
+            url.contains("my-bucket-name"),
+            "must contain 'my-bucket-name', got '{}'",
+            url
+        );
+        assert!(
+            url.contains("obj-name-2"),
+            "must contain 'obj-name-2', got '{}'",
+            url
+        );
+        assert!(url.contains("/raw/"), "must contain '/raw/', got '{}'", url);
+    }
+
+    {
+        // With bucket, object key, and raw options to false
+        let url = edge::linksharing::share_url(
+            BASE_URL,
+            &env.aws_access_key_id,
+            "my-bucket-name",
+            "obj-name-2",
+            Some(&edge::linksharing::OptionsShareURL { raw: false }),
+        )
+        .expect("shared URL without bucket");
+        assert!(
+            url.starts_with(BASE_URL),
+            "must start with '{}', got '{}'",
+            BASE_URL,
+            url
+        );
+        assert!(
+            url.contains(&env.aws_access_key_id),
+            "must contain '{}', got '{}'",
+            env.aws_access_key_id,
+            url
+        );
+        assert!(
+            url.contains("my-bucket-name"),
+            "must contain 'my-bucket-name', got '{}'",
+            url
+        );
+        assert!(
+            url.contains("obj-name-2"),
+            "must contain 'obj-name-2', got '{}'",
+            url
+        );
+        assert!(
+            !url.contains("/raw/"),
+            "must not contain '/raw/', got '{}'",
+            url
+        );
+    }
+
+    {
+        // With bucket, no object key, and raw options to false
+        let url = edge::linksharing::share_url(
+            BASE_URL,
+            &env.aws_access_key_id,
+            "my-bucket-name",
+            "",
+            Some(&edge::linksharing::OptionsShareURL { raw: false }),
+        )
+        .expect("shared URL without bucket");
+        assert!(
+            url.starts_with(BASE_URL),
+            "must start with '{}', got '{}'",
+            BASE_URL,
+            url
+        );
+        assert!(
+            url.contains(&env.aws_access_key_id),
+            "must contain '{}', got '{}'",
+            env.aws_access_key_id,
+            url
+        );
+        assert!(
+            url.contains("my-bucket-name"),
+            "must contain 'my-bucket-name', got '{}'",
+            url
+        );
+        assert!(
+            !url.contains("/raw/"),
+            "must not contain '/raw/', got '{}'",
+            url
+        );
+    }
+
+    {
+        // Invalid URL.
+        edge::linksharing::share_url(
+            "invalid-url",
+            &env.aws_access_key_id,
+            "bucket-name",
+            "object-name",
+            Some(&edge::linksharing::OptionsShareURL { raw: true }),
+        )
+        .expect_err("invalid URL");
+    }
+
+    {
+        // No access key.
+        edge::linksharing::share_url(
+            BASE_URL,
+            "",
+            "bucket-name",
+            "object-name",
+            Some(&edge::linksharing::OptionsShareURL { raw: true }),
+        )
+        .expect_err("access key cannot be empty");
+    }
+
+    {
+        // Error object key without bucket.
+        edge::linksharing::share_url(
+            BASE_URL,
+            &env.aws_access_key_id,
+            "",
+            "object-name",
+            Some(&edge::linksharing::OptionsShareURL { raw: true }),
+        )
+        .expect_err("bucket name required when object key isn't empty");
+    }
+
+    {
+        // Error options without object key.
+        edge::linksharing::share_url(
+            BASE_URL,
+            &env.aws_access_key_id,
+            "my-bucket-name",
+            "",
+            Some(&edge::linksharing::OptionsShareURL { raw: true }),
+        )
+        .expect_err("object key required when raw it's set");
+    }
+}


### PR DESCRIPTION
This PR adds add some integration tests for the Edge service API.

There is a method that I don't think can be tested with `storj/up`, but I asked on   https://github.com/storj/up/issues/59 . If it's, I will finish it and enable it in a subsequent PR.

When I was implementing these tests, I found a fault in the API design and I addressed it in this PR (see commit messages) as a fix, however, they are breaking changes.

~This PR doesn't include any version release, despite the mentioned fix, because I'm going to add some general documentation soon and send a new PR with them,  and I will create a release with the changes in this PR and the one that I will push soon.~

This PR includes a commit for releasing a new version, but it already comments that it includes some documentation changes that are in #45, so it's blocked to merge it until #45 lands in the `main` branch and I rebase this branch.

Once approved, I will publish the release, merge it and create the corresponding release tag.
 