### PR TITLE
all(doc): Fix build badge in all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uplink-rust
 
-[![CI Status](https://img.shields.io/github/workflow/status/storj-thirdparty/uplink-rust/uplink?style=for-the-badge)](https://github.com/storj-thirdparty/uplink-rust/actions/workflows/uplink.yml)
+[![CI Status](https://img.shields.io/github/actions/workflow/status/storj-thirdparty/uplink-rust/uplink.yml?branch=main&style=for-the-badge)](https://github.com/storj-thirdparty/uplink-rust/actions/workflows/uplink.yml)
 [![crates.io](https://img.shields.io/crates/v/uplink.svg?style=for-the-badge)](https://crates.io/crates/uplink)
 [![docs.rs](https://img.shields.io/docsrs/uplink?style=for-the-badge)](https://docs.rs/uplink)
 ![Crates.io](https://img.shields.io/crates/d/uplink?style=for-the-badge)

--- a/uplink-sys/README.md
+++ b/uplink-sys/README.md
@@ -1,6 +1,6 @@
 # uplink-sys
 
-[![CI Status](https://img.shields.io/github/workflow/status/storj-thirdparty/uplink-rust/uplink-sys?style=for-the-badge)](https://github.com/storj-thirdparty/uplink-rust/actions/workflows/uplink-sys.yml)
+[![CI Status](https://img.shields.io/github/actions/workflow/status/storj-thirdparty/uplink-rust/uplink-sys.yml?branch=main&style=for-the-badge)](https://github.com/storj-thirdparty/uplink-rust/actions/workflows/uplink-sys.yml)
 [![Crates.io](https://img.shields.io/crates/v/uplink-sys?style=for-the-badge)](https://crates.io/crates/uplink-sys)
 [![docs.rs](https://img.shields.io/docsrs/uplink-sys?style=for-the-badge)](https://docs.rs/uplink-sys)
 ![Crates.io](https://img.shields.io/crates/d/uplink-sys?style=for-the-badge)

--- a/uplink/README.md
+++ b/uplink/README.md
@@ -1,6 +1,6 @@
 # Storj Uplink Library for Rust
 
-[![CI Status](https://img.shields.io/github/workflow/status/storj-thirdparty/uplink-rust/uplink?style=for-the-badge)](https://github.com/storj-thirdparty/uplink-rust/actions/workflows/uplink.yml)
+[![CI Status](https://img.shields.io/github/actions/workflow/status/storj-thirdparty/uplink-rust/uplink.yml?branch=main&style=for-the-badge)](https://github.com/storj-thirdparty/uplink-rust/actions/workflows/uplink.yml)
 [![crates.io](https://img.shields.io/crates/v/uplink.svg?style=for-the-badge)](https://crates.io/crates/uplink)
 [![docs.rs](https://img.shields.io/docsrs/uplink?style=for-the-badge)](https://docs.rs/uplink)
 ![Crates.io](https://img.shields.io/crates/d/uplink?style=for-the-badge)


### PR DESCRIPTION
Update the "build" badge in all the READMEs because they changed the URL.

See: https://github.com/badges/shields/issues/8671