### PR TITLE
uplink(doc): Tidy README and TODO comments

### DIFF
--- a/uplink/Makefile
+++ b/uplink/Makefile
@@ -36,12 +36,11 @@ test-unit:
 
 tests/.tmp/env: tests/.tmp/up/storj-up
 	$(MAKE) integration-tests-credentials | grep -Ei "^export .+" > tests/.tmp/env
-	# TODO: This is a hack to get the AWS_* and STORJ_GATEWAY variables without
-	# overriding the access grants because those variable are only available using
-	# the storj-up from inside of the container, however, we cannot use the access
-	# grants because they use the docker compose service name in the URL rather
-	# than localhost and then it doesn't resolve.
-	# See: https://github.com/storj/up/issues/45#issuecomment-1288808260
+	# TODO(github.com/storj-thirdparty/uplink-rust/issues/48): This is a hack to get the AWS_* and
+	# STORJ_GATEWAY variables without overriding the access grants because those variable are only
+	# available using the storj-up from inside of the container, however, we cannot use the access
+	# grants because they use the docker compose service name in the URL rather than localhost and
+	# then it doesn't resolve.
 	@cd tests; docker compose exec -T satellite-api storj-up credentials --s3 -e \
 		-a http://authservice:8888 -s satellite-api \
 		| grep -E 'AWS|STORJ_GATEWAY' >> .tmp/env

--- a/uplink/README.md
+++ b/uplink/README.md
@@ -12,12 +12,18 @@ Safe and idiomatic Rust crate library for the [Storj Uplink Library][storj-uplin
 This crate has implemented all the functionalities offered by the `uplink-sys`
 create and it's fully documented.
 
-It has also several unit-tests but it lacks of integration tests (see
-[Development plan and status section](#development-plan-and-status)).
-Integration test would prove that it works as expected.
+It has several unit-tests and integration tests which prove that a big part of
+the public API works as expected.
 
-We consider its current status beta and we advice that  it's NOT READY for
-production yet.
+The crate is fully documented and the `docs` contains documentation outside of
+the API (types, function, etc.).
+
+We consider its current status beta and it can be use for production systems
+with care because, despite of the integration tests, we don't know any reference
+that this crate is used in any production application.
+
+If you're using this crate in any of your applications, we'd love that you open
+an issue and you tell us about.
 
 ## Implementation
 
@@ -38,84 +44,7 @@ use a Docker version without the `compose` command,  using the `docker-compose`,
 however, you will have to run by hand or make an straightforward change in the
 Makefile.
 
-### Development plan and status
-
-General entities:
-
-- [X] [Access](https://pkg.go.dev/storj.io/uplink#Access)
-- [X] [Bucket](https://pkg.go.dev/storj.io/uplink#Bucket)
-- [X] [Bucket Iterator](https://pkg.go.dev/storj.io/uplink#BucketIterator)
-- [X] [Commit Upload Options](https://pkg.go.dev/storj.io/uplink#CommitUploadOptions)
-- [X] [Config](https://pkg.go.dev/storj.io/uplink#Config)
-- [X] [Custom Metadata](https://pkg.go.dev/storj.io/uplink#CustomMetadata)
-- [X] [Download](https://pkg.go.dev/storj.io/uplink#Download)
-- [X] [Download Options](https://pkg.go.dev/storj.io/uplink#DownloadOptions)
-- [X] [Encryption Key](https://pkg.go.dev/storj.io/uplink#EncryptionKey)
-- [X] [List Buckets Options](https://pkg.go.dev/storj.io/uplink#ListBucketsOptions)
-- [X] [List Objects Options](https://pkg.go.dev/storj.io/uplink#ListObjectsOptions)
-- [X] [List Uploads Options](https://pkg.go.dev/storj.io/uplink#ListUploadsOptions)
-- [X] [List Upload Parts Options](https://pkg.go.dev/storj.io/uplink#ListUploadPartsOptions)
-- [X] [Move Object Options](https://pkg.go.dev/storj.io/uplink#MoveObjectOptions)
-- [X] [Object](https://pkg.go.dev/storj.io/uplink#Object)
-- [X] [Object Iterator](https://pkg.go.dev/storj.io/uplink#ObjectIterator)
-- [X] [Part](https://pkg.go.dev/storj.io/uplink#Part)
-- [X] [Part Iterator](https://pkg.go.dev/storj.io/uplink#PartIterator)
-- [X] [Part Upload](https://pkg.go.dev/storj.io/uplink#PartUpload)
-- [X] [Permission](https://pkg.go.dev/storj.io/uplink#Permission)
-- [X] [Project](https://pkg.go.dev/storj.io/uplink#Project)
-- [X] [Share Prefix](https://pkg.go.dev/storj.io/uplink#SharePrefix)
-- [X] [System Metadata](https://pkg.go.dev/storj.io/uplink#SystemMetadata)
-- [X] [Upload](https://pkg.go.dev/storj.io/uplink#Upload)
-- [X] [Upload Info](https://pkg.go.dev/storj.io/uplink#UploadInfo)
-- [X] [Upload Iterator](https://pkg.go.dev/storj.io/uplink#UploadIterator)
-- [X] [Upload Options](https://pkg.go.dev/storj.io/uplink#UploadOptions)
-
-
-Edge entities:
-
-- [X] [Config](https://pkg.go.dev/storj.io/uplink/edge#Config)
-- [X] [Credentials](https://pkg.go.dev/storj.io/uplink/edge#Credentials)
-- [X] [Register Access Options](https://pkg.go.dev/storj.io/uplink/edge#RegisterAccessOptions)
-- [X] [Share URL Options](https://pkg.go.dev/storj.io/uplink/edge#ShareURLOptions)
-
-
-Integration tests:
-
-- [X] Access Grant.
-  - [X] Request an Access Grant with passphrase.
-  - [X] Parse one.
-  - [X] Share one.
-  - [X] Override an encryption key of a specific Bucket and prefix.
-- [X] Project
-  - [X] Create a Bucket.
-  - [X] Try to create a Bucket which already exists.
-  - [X] Ensure a Bucket, an existing and non-existing one.
-  - [X] Stat a Bucket.
-  - [X] List Buckets.
-  - [X] Upload an Object.
-  - [X] Upload an Object with Custom Metadata.
-  - [X] Multipart upload.
-  - [X] Download an Object.
-  - [X] Stat an Object.
-  - [X] List Objects with System and Custom Metadata.
-  - [X] List Objects without System and Custom Metadata.
-  - [X] Copy an object.
-  - [X] Move an object.
-  - [X] Delete an Object.
-  - [X] Delete an empty Bucket.
-  - [X] Delete a Bucket with objects.
-- [X] Edge.
-  - [X] Join a share URL.
   - [ ] Register an Access Grant. - NOTE: [waiting to know if we can test it with storj/up](https://github.com/storj/up/issues/59)
-
-General:
-
-- [X] Add a CI solution (Travis, Github actions, etc.) for running tests,
-      linters on every PR and when something is merge into the `main` branch.
-- [X] Add general documentation about the Storj network and its entities
-      mimicking the original [Go Uplink package](https://pkg.go.dev/storj.io/uplink#section-documentation).
-- [X] Add some documentation about the crate design and implementation if the
-      documentation of each module, types, functions, etc., aren't enough.
 
 
 

--- a/uplink/src/error.rs
+++ b/uplink/src/error.rs
@@ -146,7 +146,8 @@ impl Args {
     ///
     /// It panics because it makes easier to find a BUG on the `name`'s passed value.
     ///
-    /// TODO: implement the `name`'s constraints validation and panic if the validation fails.
+    /// TODO(https://github.com/storj-thirdparty/uplink-rust/issues/52): Implement the `name`'s
+    /// constraints validation and panic if the validation fails.
     fn new(names: &str, msg: &str) -> Self {
         Args {
             names: String::from(names),

--- a/uplink/src/object.rs
+++ b/uplink/src/object.rs
@@ -276,8 +276,7 @@ impl Drop for Download {
         // correctly created `UplinkDownloadResult` value.
         unsafe {
             // At this point we cannot do anything about the error, so discarded.
-            // TODO: find out if retrying the operation it's the right thing to do for some of the
-            // kind of errors that this function may return.
+            // TODO(https://github.com/storj-thirdparty/uplink-rust/issues/51).
             let _ = ulksys::uplink_close_download(self.inner.download);
             ulksys::uplink_free_download_result(self.inner);
         }

--- a/uplink/src/project.rs
+++ b/uplink/src/project.rs
@@ -641,8 +641,7 @@ impl Drop for Project {
         // correctly created `UplinkProjectResult` value.
         unsafe {
             // At this point we cannot do anything about the error, so discarded.
-            // TODO: find out if retrying the operation it's the right thing to do for some of the
-            // kind of errors that this function may return.
+            // TODO(https://github.com/storj-thirdparty/uplink-rust/issues/51).
             let _ = ulksys::uplink_close_project(self.inner.project);
             ulksys::uplink_free_project_result(self.inner);
         }

--- a/uplink/tests/edge_test.rs
+++ b/uplink/tests/edge_test.rs
@@ -5,10 +5,12 @@ mod common;
 
 const AUTH_SERVICE_URL: &str = "localhost:8888";
 
-// #[test]
+// TODO(https://github.com/storj-thirdparty/uplink-rust/issues/49): we need new Uplink API for
+// being able to run this test successfully. Remove the `ignore` annotation and adjust the test
+// with the new API.
+#[test]
+#[ignore]
 fn integration_config_register_access() {
-    // TODO: See evolution of https://github.com/storj/up/issues/59 for enabling or removing this
-    // test.
     let env = common::Environment::load();
     let access_grant = Grant::new(&env.access_grant).expect("access grant parsing");
 

--- a/uplink/tests/uploads_test.rs
+++ b/uplink/tests/uploads_test.rs
@@ -124,8 +124,8 @@ fn integration_upload_multipart_commit() {
         .next()
         .expect("an item in the uploads list")
         .expect("a pending upload");
-    // TODO: uncomment the following assertion when the bug is fixed:
-    // https://github.com/storj/storj/issues/5298
+    // TODO(https://github.com/storj-thirdparty/uplink-rust/issues/50) uncomment the following
+    // assertion.
     // assert_eq!(upload_info.upload_id, item.upload_id, "pending upload key");
     assert_eq!(object_multipart_key, item.key, "pending upload key");
     assert!(!item.is_prefix, "pending upload is prefix");


### PR DESCRIPTION
All the planned end-to-end tests were finished in version v0.6.0 but the
README wasn't tidied according to them.

This commit tidies the README and also identifies all the `TODO`
comments with an issue for tracking them in the issue tracker for having
a good overview of what has to be done.

NOTE I created all the issues referred to by the `TODO` comments.