### PR TITLE
uplink(chore): Bump storj-up version

### DIFF
--- a/uplink/Makefile
+++ b/uplink/Makefile
@@ -64,7 +64,7 @@ tests/.tmp/up/storj-up: tests/.tmp/up
 tests/.tmp/up:
 	mkdir -p tests/.tmp
 	cd tests/.tmp; git clone https://github.com/storj/up.git
-	cd tests/.tmp/up; git checkout v1.0.0
+	cd tests/.tmp/up; git checkout v1.1.0
 
 ## Publish crate ##
 .PHONY: publish-test

--- a/uplink/tests/docker-compose.yaml
+++ b/uplink/tests/docker-compose.yaml
@@ -6,6 +6,9 @@ services:
     - run
     - --defaults=dev
     environment:
+      STORJUP_AUTHSERVICE: http://authservice:8888
+      STORJUP_S3: "true"
+      STORJUP_SATELLITE: satellite-api
       STORJ_ALLOWED_SATELLITES: 12whfK1EDvHJtajBiAUeajQLYcWqxcQmdYQU5zX5cCf6bAxfgu4@satellite-api:7777
       STORJ_AUTH_TOKEN: super-secret
       STORJ_DEBUG_ADDR: 0.0.0.0:11111
@@ -17,7 +20,7 @@ services:
       STORJ_METRICS_APP_SUFFIX: sim
       STORJ_ROLE: authservice
       STORJ_WAIT_FOR_SATELLITE: "true"
-    image: img.dev.storj.io/storjup/edge:1.36.0
+    image: img.dev.storj.io/storjup/edge:1.39.0
     networks:
       default: null
     ports:
@@ -45,6 +48,9 @@ services:
     - run
     - --defaults=dev
     environment:
+      STORJUP_AUTHSERVICE: http://authservice:8888
+      STORJUP_S3: "true"
+      STORJUP_SATELLITE: satellite-api
       STORJ_AUTH_BASE_URL: http://authservice:8888
       STORJ_AUTH_TOKEN: super-secret
       STORJ_AUTH_URL: http://authservice:8888
@@ -54,7 +60,7 @@ services:
       STORJ_METRICS_APP_SUFFIX: sim
       STORJ_SERVER_ADDRESS: 0.0.0.0:9999
       STORJ_WAIT_FOR_SATELLITE: "true"
-    image: img.dev.storj.io/storjup/edge:1.36.0
+    image: img.dev.storj.io/storjup/edge:1.39.0
     networks:
       default: null
     ports:
@@ -68,12 +74,15 @@ services:
     - run
     - --defaults=dev
     environment:
+      STORJUP_AUTHSERVICE: http://authservice:8888
+      STORJUP_S3: "true"
+      STORJUP_SATELLITE: satellite-api
       STORJ_AUTH_SERVICE_BASE_URL: http://authservice:8888
       STORJ_AUTH_SERVICE_TOKEN: super-secret
       STORJ_DEBUG_ADDR: 0.0.0.0:11111
       STORJ_PUBLIC_URL: http://linksharing:9090,http://localhost:9090
       STORJ_WAIT_FOR_SATELLITE: "true"
-    image: img.dev.storj.io/storjup/edge:1.36.0
+    image: img.dev.storj.io/storjup/edge:1.39.0
     networks:
       default: null
     ports:
@@ -93,6 +102,8 @@ services:
     - --defaults=dev
     - --identity-dir=/var/lib/storj/identities/1
     environment:
+      STORJUP_AUTHSERVICE: http://authservice:8888
+      STORJUP_SATELLITE: satellite-api
       STORJ_ADMIN_ADDRESS: 0.0.0.0:8080
       STORJ_ADMIN_STATIC_DIR: /var/lib/storj/storj/satellite/admin/ui/build
       STORJ_CONSOLE_AUTH_TOKEN: my-suppa-secret-key
@@ -112,7 +123,7 @@ services:
       STORJ_PAYMENTS_STORJSCAN_ENDPOINT: http://storjscan:12000
       STORJ_ROLE: satellite-admin
       STORJ_WAIT_FOR_SATELLITE: "true"
-    image: img.dev.storj.io/storjup/storj:1.62.4
+    image: img.dev.storj.io/storjup/storj:1.65.1
     networks:
       default: null
     ports:
@@ -128,6 +139,8 @@ services:
     - --defaults=dev
     - --identity-dir=/var/lib/storj/identities/1
     environment:
+      STORJUP_AUTHSERVICE: http://authservice:8888
+      STORJUP_SATELLITE: satellite-api
       STORJ_ADDRESS: 0.0.0.0:7777
       STORJ_CONSOLE_ADDRESS: 0.0.0.0:10000
       STORJ_CONSOLE_AUTH_TOKEN_SECRET: my-suppa-secret-key
@@ -160,7 +173,7 @@ services:
       STORJ_SERVER_REVOCATION_DBURL: redis://redis:6379?db=1
       STORJ_SERVER_USE_PEER_CA_WHITELIST: "false"
       STORJ_WAIT_FOR_DB: "true"
-    image: img.dev.storj.io/storjup/storj:1.62.4
+    image: img.dev.storj.io/storjup/storj:1.65.1
     networks:
       default: null
     ports:
@@ -179,6 +192,8 @@ services:
     - --defaults=dev
     - --identity-dir=/var/lib/storj/identities/1
     environment:
+      STORJUP_AUTHSERVICE: http://authservice:8888
+      STORJUP_SATELLITE: satellite-api
       STORJ_DATABASE: cockroach://root@cockroach:26257/master?sslmode=disable
       STORJ_DEBUG_ADDR: 0.0.0.0:11111
       STORJ_DEFAULTS: dev
@@ -198,7 +213,7 @@ services:
       STORJ_PAYMENTS_STORJSCAN_ENDPOINT: http://storjscan:12000
       STORJ_ROLE: satellite-core
       STORJ_WAIT_FOR_SATELLITE: "true"
-    image: img.dev.storj.io/storjup/storj:1.62.4
+    image: img.dev.storj.io/storjup/storj:1.65.1
     networks:
       default: null
   storagenode:
@@ -209,6 +224,8 @@ services:
     deploy:
       replicas: 10
     environment:
+      STORJUP_AUTHSERVICE: http://authservice:8888
+      STORJUP_SATELLITE: satellite-api
       STORJ_CONSOLE_STATIC_DIR: /var/lib/storj/web/storagenode
       STORJ_DEBUG_ADDR: 0.0.0.0:11111
       STORJ_DEFAULTS: dev
@@ -225,7 +242,7 @@ services:
       STORJ_STORAGE_ALLOCATED_DISK_SPACE: 1G
       STORJ_VERSION_SERVER_ADDRESS: http://versioncontrol:8080/
       STORJ_WAIT_FOR_SATELLITE: "true"
-    image: img.dev.storj.io/storjup/storj:1.62.4
+    image: img.dev.storj.io/storjup/storj:1.65.1
     networks:
       default: null
   uplink:
@@ -234,7 +251,7 @@ services:
     - infinity
     environment:
       STORJ_ROLE: uplink
-    image: img.dev.storj.io/storjup/storj:1.62.4
+    image: img.dev.storj.io/storjup/storj:1.65.1
     networks:
       default: null
   versioncontrol:
@@ -249,11 +266,13 @@ services:
       BINARY_STORAGENODE_UPDATER_ROLLOUT_SEED: "0000000000000000000000000000000000000000000000000000000000000001"
       BINARY_UPLINK_ROLLOUT_SEED: "0000000000000000000000000000000000000000000000000000000000000001"
       DEFAULTS: dev
+      STORJUP_AUTHSERVICE: http://authservice:8888
+      STORJUP_SATELLITE: satellite-api
       STORJ_DEBUG_ADDR: 0.0.0.0:11111
       STORJ_DEFAULTS: dev
       STORJ_LOG_LEVEL: debug
       STORJ_METRICS_APP_SUFFIX: sim
-    image: img.dev.storj.io/storjup/storj:1.62.4
+    image: img.dev.storj.io/storjup/storj:1.65.1
     networks:
       default: null
     ports:


### PR DESCRIPTION
Bump the storj-up version for using the last published release.

Closes #47 