### PR TITLE
Compile storj-up without QUIC

### DIFF
--- a/.github/workflows/uplink-sys.yml
+++ b/.github/workflows/uplink-sys.yml
@@ -5,10 +5,17 @@ on:
     branches: main
     paths:
       - 'uplink-sys/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'docker-compose.yaml'
+      - 'Makefile'
   pull_request:
-    branches: main
     paths:
       - 'uplink-sys/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'docker-compose.yaml'
+      - 'Makefile'
 
 env:
   # Show colors for cargo output

--- a/.github/workflows/uplink.yml
+++ b/.github/workflows/uplink.yml
@@ -5,9 +5,17 @@ on:
     branches: main
     paths:
       - 'uplink/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'docker-compose.yaml'
+      - 'Makefile'
   pull_request:
     paths:
       - 'uplink/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'docker-compose.yaml'
+      - 'Makefile'
 
 env:
   # Show colors for cargo output

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ integration-tests-env-down:
 		| grep -E 'AWS|STORJ_GATEWAY' >> .tmp/env
 
 .tmp/up/storj-up: .tmp/up
-	cd .tmp/up; go build -o storj-up
+	cd .tmp/up; go build -tags noquic -o storj-up
 
 .tmp/up:
 	mkdir -p .tmp


### PR DESCRIPTION
The currently used version of storj-up (v1.0.0) doesn't compile with Go 1.20 because it relies on a version of Go QUIC as a transient dependency that doesn't compile with this Go version.

A current workaround is to disable QUIC for building storj-up until we bump storj-up to a newer published version that works with Go 1.20 without disabling QUIC.

In order to run the CI I had to modify the workflows, so there is a commit that just does that and it has its proper commit message.
Please see the commits message individually for more details and if you __MERGE THIS__ keep the commits, __DO NOT SQUASH__ them.