### PR TITLE
all(build): Change shebang for better compatibility

### DIFF
--- a/uplink-sys/Makefile
+++ b/uplink-sys/Makefile
@@ -6,7 +6,7 @@ LOCAL_ABS_CRATE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # Makefile special variables #
 
 .DEFAULT_GOAL := build
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # Targets #
 

--- a/uplink/Makefile
+++ b/uplink/Makefile
@@ -1,7 +1,7 @@
 # Makefile special variables #
 
 .DEFAULT_GOAL := lint
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # Targets #
 


### PR DESCRIPTION
NixOS doesn't have `#!/bin/bash`. Bash can be found on all Linuxes with
`#!/usr/bin/env bash` so it's better to use that shebang. 

This doesn't actually enable building on NixOS since `uplink-c` also
needs upgrading to a version that doesn't use `#!/bin/bash`. This was done in
https://github.com/storj/uplink-c/pull/24

related https://github.com/storj-thirdparty/uplink-rust/issues/49

