### PR TITLE
uplink(chore): Bump crate version

### DIFF
--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ivan Fraixedes <ivan@fraixed.es>"]
 edition = "2021"
 description = "Idiomatic and safe Rust binding for the Storj Lib Uplink"


### PR DESCRIPTION
Bump the crate version to release the last fix.

The new crate release has already been published.