### PR TITLE
uplink-sys(build): Fix bindgen deprecation

### DIFF
--- a/uplink-sys/build.rs
+++ b/uplink-sys/build.rs
@@ -111,7 +111,7 @@ fn main() {
                 .to_string_lossy(),
         )
         // Also make headers included by main header dependencies of the build
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Generate bindings
         .generate()
         .expect("Error generating bindings.")


### PR DESCRIPTION
We bumped bindgen, but we didn't realize that the new version deprecated an API type that we were using.

This commit change the deprecated API type by the call to a constructor that replaces it, see
https://docs.rs/bindgen/0.69.4/bindgen/constant.CargoCallbacks.html