### PR TITLE
uplink(fix): Add missing doc unsafe blocks & lint

### DIFF
--- a/uplink/src/edge/linksharing.rs
+++ b/uplink/src/edge/linksharing.rs
@@ -33,6 +33,11 @@ pub fn share_url(
     let key = helpers::cstring_from_str_fn_arg("key", key)?;
     let res: ulksys::UplinkStringResult;
 
+    // SAFETY: We are sure the CString(s) are valid because we created them from valid Rust strings.
+    // We  get raw pointers to them and to pass them to the FFI function.
+    // We are sure the FFI function will not free them.
+    // We take the ownership back for the ones that we transferred the ownership to the FFI
+    // function to drop them and not leak memory.
     unsafe {
         let c_base_url = base_url.into_raw();
         let c_access_key = access_key.into_raw();

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -8,6 +8,7 @@
 //! documentation and error messages when referencing the low level crate.
 
 #![deny(missing_docs)]
+#![deny(clippy::undocumented_unsafe_blocks)]
 
 pub mod access;
 pub mod bucket;

--- a/uplink/src/object/upload.rs
+++ b/uplink/src/object/upload.rs
@@ -84,6 +84,8 @@ impl Upload {
 
     /// Updates the custom metadata to be included with the object.
     pub fn set_custom_metadata(&mut self, metadata: &mut metadata::Custom) -> Result<()> {
+        // SAFETY: We are sure that FFI doesn't take ownership of the two parameters.
+        // Metadata FFI type is obtained from a safe wrapper.
         let err = unsafe {
             ulksys::uplink_upload_set_custom_metadata(
                 self.inner.upload,
@@ -236,6 +238,9 @@ impl Info {
         let is_prefix = upload.is_prefix;
         let upload_id;
         let key;
+        // SAFETY: We have guarantee that upload fields aren't null through the `ensure` method
+        // call of the `Ensurer` trait. We make a copy of the C string pointers to Rust strings,
+        // and we free the memory of the C strings to not leak memory.
         unsafe {
             upload_id = CStr::from_ptr(upload.upload_id)
                 .to_str()
@@ -445,6 +450,9 @@ impl PartUpload {
         }
 
         let c_etag = res.expect("BUG: this result was verified to be an Ok, probably the check has been accidentally removed due to a refactoring");
+        // SAFETY: We get a pointer from a Rust string after guarantee that doesn't contain any 0
+        // byte (NULL byte) and we pass it to the FFI.
+        // `self.inner` is guarantee to be valid by the constructor of this struct.
         let err = unsafe {
             ulksys::uplink_part_upload_set_etag(
                 self.inner.part_upload,


### PR DESCRIPTION
Document unsafe blocks that didn't have a `SAFETY` documentation and add the Clippy linter rules to detect unsafe undocumented blocks.