### PR TITLE
uplink-sys(fix): Make build copying more resilient

### DIFF
--- a/uplink-sys/build.rs
+++ b/uplink-sys/build.rs
@@ -32,7 +32,7 @@ fn main() {
     // Copy project to OUT_DIR for building
     Command::new("cp")
         .args([
-            "-R",
+            "-Rf",
             &uplink_c_src.to_string_lossy(),
             &uplink_c_dir.to_string_lossy(),
         ])


### PR DESCRIPTION
This fixes an issue where:

  1. User tries to build before initializing all submodules.
  2. `uplink-c` directory is empty and copied into build.
  3. Build fails but leaves empty `uplink-c` directory in build directory
  4. User initializes `uplink-c` and then tries to build again without cleaning.
  5. `uplink-c` gets nested in a second level deeper, causing build issues.