### PR TITLE
uplink-sys,uplink(release): Release new versions

### DIFF
--- a/uplink-sys/Cargo.toml
+++ b/uplink-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink-sys"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Cameron Fyfe <cameron.j.fyfe@gmail.com>", "utropicmedia"]
 edition = "2021"
 links = "uplink"

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Ivan Fraixedes <ivan@fraixed.es>"]
 edition = "2021"
 description = "Idiomatic and safe Rust binding for the Storj Lib Uplink"
@@ -12,7 +12,7 @@ homepage = "https://storj.io"
 
 
 [dependencies]
-uplink-sys = { path = "../uplink-sys", version = "0.7.0" }
+uplink-sys = { path = "../uplink-sys", version = "0.7.1" }
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
Release a new version of each crate to include some merged fixes.

The uplink version includes a fix of a used after free bug. This fix required have breaking changes, unfortunately.

They are published.