### PR TITLE
all(build): Enable the resolver v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["uplink", "uplink-sys"]
+resolver = "2"


### PR DESCRIPTION
Enable the resolver version 2 at the workspace level, otherwise, version 1 is used, besides showing a warning about it.