### PR TITLE
uplink(release): Release new version (v0.11.0)

### DIFF
--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uplink"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["Ivan Fraixedes <ivan@fraixed.es>"]
 edition = "2021"
 description = "Idiomatic and safe Rust binding for the Storj Lib Uplink"
@@ -12,7 +12,7 @@ homepage = "https://storj.io"
 
 
 [dependencies]
-uplink-sys = { path = "../uplink-sys", version = "0.7.2" }
+uplink-sys = { path = "../uplink-sys", version = "0.8.0" }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = "0.9.1"


### PR DESCRIPTION
Release a new uplink crate version that uses the last published uplink-sys version (v0.8.0).

This commit also bumps the uplink crate dependencies.

On hold until #94 is merged.