### PR TITLE
all(ci): Fix failing integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,6 @@ integration-tests-env-down:
 .tmp/up:
 	mkdir -p .tmp
 	cd .tmp; git clone https://github.com/storj/up.git
-	cd .tmp/up; git checkout v1.2.7
+	cd .tmp/up; git checkout v1.2.10
 
 .tmp/up/docker-compose.yaml: .tmp/up/storj-up

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ clean: integration-tests-env-down
 
 .PHONY: integration-tests-env-up
 integration-tests-env-up: .tmp/up/docker-compose.yaml
-	cd .tmp/up; docker compose up -d
+	cd .tmp/up; docker compose up -d --wait --wait-timeout 120 \
+		|| { echo "Docker compose services failed to start."; docker compose down; exit 1; }
 	$(MAKE) .tmp/env
 
 .PHONY: integration-tests-env-down

--- a/uplink/src/error.rs
+++ b/uplink/src/error.rs
@@ -126,8 +126,8 @@ pub struct Args {
     /// * When the parameter is a list (vector, array, etc.), the invalid items can be
     ///   __optionally__ indicated using square brackets (e.g. `l[3,5,7]`).
     /// * when the parameter is struct, the invalid fields or method return return values can be
-    ///    __optionally__ indicated using curly brackets (e.g invalid field: `person{name}`, invalid
-    ///    method return value: `person{full_name()}`, invalid fields/methods:
+    ///   __optionally__ indicated using curly brackets (e.g invalid field: `person{name}`, invalid
+    ///   method return value: `person{full_name()}`, invalid fields/methods:
     ///   `employee{name, position()}`).
     /// * When several parameters are invalid, its values is the parameters names wrapped in round
     ///   brackets (e.g. `(p1,p3)`); it also accepts any above combination of parameters types

--- a/uplink/src/object.rs
+++ b/uplink/src/object.rs
@@ -257,7 +257,7 @@ impl std::io::Read for Download {
                 }
 
                 use std::io::{Error as IOErr, ErrorKind};
-                return Err(IOErr::new(ErrorKind::Other, err));
+                return Err(IOErr::other(err));
             }
 
             if read_res.bytes_read != 0 {

--- a/uplink/src/object/upload.rs
+++ b/uplink/src/object/upload.rs
@@ -119,8 +119,7 @@ impl std::io::Write for Upload {
         // `write` that the caller should to write the rest of the bytes, we return the error
         // returned on the previous call.
         if !self.inner.error.is_null() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(std::io::Error::other(
                 Error::new_uplink(self.inner.error)
                     .expect("BUG: missing a non NULL verification previous to this call"),
             ));
@@ -145,8 +144,7 @@ impl std::io::Write for Upload {
             // There is an error and the operation didn't upload any byte, so we return the error
             // directly.
             if uc_res.bytes_written == 0 {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                return Err(std::io::Error::other(
                     Error::new_uplink(uc_res.error)
                         .expect("BUG: missing a non NULL verification previous to this call"),
                 ));
@@ -482,8 +480,7 @@ impl std::io::Write for PartUpload {
         // `write` that the caller should to write the rest of the bytes, we return the error
         // returned on the previous call.
         if !self.inner.error.is_null() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(std::io::Error::other(
                 Error::new_uplink(self.inner.error)
                     .expect("BUG: missing a non NULL verification previous to this call"),
             ));
@@ -508,8 +505,7 @@ impl std::io::Write for PartUpload {
             // There is an error and the operation didn't upload any byte, so we return the error
             // directly.
             if uc_res.bytes_written == 0 {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                return Err(std::io::Error::other(
                     Error::new_uplink(uc_res.error)
                         .expect("BUG: missing a non NULL verification previous to this call"),
                 ));


### PR DESCRIPTION
This adds the `--wait` and `--wait-timeout` options to the `docker compose up` so that containers are ready before running tests.

This also bumps `storj/up` to v1.2.10, which adds the fix to `versioncheck` (removes it), so that the integration test environment successfully loads up.

Fixes #96 